### PR TITLE
Pass false for special tokens to be compatible with llama.cpp commit 40f74e4

### DIFF
--- a/Sources/LLM/LLM.swift
+++ b/Sources/LLM/LLM.swift
@@ -393,12 +393,12 @@ extension Model {
     public func decode(_ token: Token, with multibyteCharacter: inout [CUnsignedChar]) -> String {
         var bufferLength = 16
         var buffer: [CChar] = .init(repeating: 0, count: bufferLength)
-        let actualLength = Int(llama_token_to_piece(self, token, &buffer, Int32(bufferLength)))
+        let actualLength = Int(llama_token_to_piece(self, token, &buffer, Int32(bufferLength), false))
         guard 0 != actualLength else { return "" }
         if actualLength < 0 {
             bufferLength = -actualLength
             buffer = .init(repeating: 0, count: bufferLength)
-            llama_token_to_piece(self, token, &buffer, Int32(bufferLength))
+            llama_token_to_piece(self, token, &buffer, Int32(bufferLength), false)
         } else {
             buffer.removeLast(bufferLength - actualLength)
         }


### PR DESCRIPTION
Since commit [40f74e4](https://github.com/ggerganov/llama.cpp/commit/40f74e4d739e9250431cf339ae7588b28d8d0663) from llama.cpp, this library is broken due to changed in API. This commit addresses the issue with passing "false" to show special tokens in the output.