### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             targets: ["LLM"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ggerganov/llama.cpp/", branch: "master"),
+        .package(url: "https://github.com/ggerganov/llama.cpp", branch: "master"),
         .package(url: "https://github.com/kishikawakatsumi/swift-power-assert", from: "0.12.0"),
     ],
     targets: [


### PR DESCRIPTION
Small fix on Llama.cpp package dependency address, it lead to errors on Xcode 16.2 Beta, tested on a forked version of this repo and it solves the issue