### PR TITLE
make generateWithConstraints public

### DIFF
--- a/Sources/LLM/LLM.swift
+++ b/Sources/LLM/LLM.swift
@@ -338,7 +338,7 @@ public actor LLMCore {
         return debugLastGeneratedTokens
     }
     
-    func generateWithConstraints(from input: String, jsonSchema: String) throws -> String {
+    public func generateWithConstraints(from input: String, jsonSchema: String) throws -> String {
         debugLastGeneratedTokens = []
         guard prepareContext(for: input) else { throw LLMError.contextCreationFailed }
         guard let parsedSchema = parseJSONSchema(jsonSchema) else { throw LLMError.contextCreationFailed }


### PR DESCRIPTION
We want to use the schema directly without structs. This allows for overriding/implement the respond function with custom logic.