### PR TITLE
Add awaitable resetAndWait() for deterministic KV reset

### DIFF
--- a/Sources/LLM/LLM.swift
+++ b/Sources/LLM/LLM.swift
@@ -1461,6 +1461,16 @@ open class LLM: ObservableObject {
         history.removeAll()
         Task { await core.resetContext() }
     }
+
+    /// QuietPilot patch (Sprint 55 US-55.1): structured, AWAITABLE reset. Upstream
+    /// reset() fires `Task { await core.resetContext() }` unawaited, so the KV clear
+    /// races the next generation's prepareContext and can zero the context mid-decode
+    /// (empty/truncated output). Awaiting the clear makes it provably ordered before the
+    /// next respond(). Pinned by github.com/tonyphoang/ios_voice_assistant.
+    public func resetAndWait() async {
+        history.removeAll()
+        await core.resetContext()
+    }
     
     open func recoverFromLengthy(_ input: borrowing String, to output: borrowing AsyncStream<String>.Continuation) {
         output.yield("TL;DR")


### PR DESCRIPTION
### Problem
`reset()` clears `history` synchronously but enqueues the KV clear as an unstructured task:

```swift
public func reset() {
    history.removeAll()
    Task { await core.resetContext() }
}
```

Because that `Task` is fire-and-forget, `core.resetContext()` is **unordered** against the next `respond(to:)`'s `core.prepareContext(...)` on the same actor. In a tight back-to-back generation loop (e.g. map-reduce over transcript chunks), the reset can land *mid-decode* of the next generation — zeroing the context and producing empty/truncated output — and a stale `currentTokenCount` can make a prompt that fits the window falsely overflow `maxTokenCount`.

There's currently no public way to await the clear: `resetContext()` is `internal`, and `getLastGeneratedTokens()` reflects `debugLastGeneratedTokens`, which the streaming path doesn't populate and `resetContext()` doesn't clear — so it can't be polled to detect the reset landing.

### Change
Add a structured, awaitable counterpart so callers can order the reset before the next generation:

```swift
public func resetAndWait() async {
    history.removeAll()
    await core.resetContext()
}
```

One actor hop, fully ordered before the next `respond()`'s `prepareContext`, and leaves `currentTokenCount` at 0. Purely additive — `reset()` is unchanged.