### PR TITLE
Fix reset/stop-sequence races with awaitable variants, and add KV prefix caching

### DIFF
--- a/Sources/LLM/LLM.swift
+++ b/Sources/LLM/LLM.swift
@@ -310,7 +310,7 @@ public actor LLMCore {
         return true
     }
     
-    func resetContext() {
+    public func resetContext() {
         currentTokenCount = 0
         tokenBuffer.removeAll()
         shouldContinuePredicting = false
@@ -1460,6 +1460,31 @@ open class LLM: ObservableObject {
     public func reset() {
         history.removeAll()
         Task { await core.resetContext() }
+    }
+    
+    /// Reset conversation state and await the context clear. Unlike `reset()`, whose
+    /// KV clear runs in a fire-and-forget task, this guarantees the clear has landed
+    /// before a subsequent `respond` enqueues on the core actor - a `respond` racing
+    /// ahead of the clear decodes onto stale cells and produces degenerate output.
+    public func resetContext() async {
+        history.removeAll()
+        await core.resetContext()
+    }
+    
+    /// Await until the current template's stop sequence and thinking tokens are
+    /// applied on the core. The `template` didSet applies them via a fire-and-forget
+    /// task, so a `respond` issued right after setting `template` can start
+    /// generating BEFORE the stop sequence lands - the model then runs straight
+    /// through its end-of-turn marker. Call (and await) this after setting
+    /// `template` and before `respond`.
+    public func syncTemplate() async {
+        if let template {
+            await core.setStopSequence(template.stopSequence)
+            await setupThinkingTokens(from: template)
+        } else {
+            await core.setStopSequence(nil)
+            await core.setThinkingTokens(start: nil, end: nil, startMarker: nil, endMarker: nil)
+        }
     }
     
     open func recoverFromLengthy(_ input: borrowing String, to output: borrowing AsyncStream<String>.Continuation) {

--- a/Sources/LLM/LLM.swift
+++ b/Sources/LLM/LLM.swift
@@ -211,7 +211,10 @@ public actor LLMCore {
         
         tokenBuffer.removeAll()
         
-        var tokens = encode(input)
+        // BOS belongs only at the very start of the context - when continuing after
+        // kept tokens (multi-turn or a kept prefix), injecting BOS mid-stream skews
+        // the model's state.
+        var tokens = encode(input, shouldAddBOS: currentTokenCount == 0)
         if tokens.last == nullToken { tokens.removeLast() }
         
         let initialCount = tokens.count
@@ -316,6 +319,29 @@ public actor LLMCore {
         shouldContinuePredicting = false
         // Clear all sequences to ensure clean state
         llama_memory_seq_rm(llama_get_memory(context), -1, -1, -1)
+    }
+    
+    /// Like `resetContext()`, but keep the first `n` tokens' KV cells (a previously
+    /// `ingest`ed stable prefix). The next `prepareContext` continues at position
+    /// `n`, skipping re-decode of the prefix - the dominant per-turn latency cost
+    /// when the prefix is a large system prompt.
+    public func resetContext(keepingTokens n: Int32) {
+        guard n > 0 else { return resetContext() }
+        currentTokenCount = n
+        tokenBuffer.removeAll()
+        shouldContinuePredicting = false
+        llama_memory_seq_rm(llama_get_memory(context), -1, n, -1)
+    }
+    
+    /// Decode `text` into the context WITHOUT starting generation - for pre-warming
+    /// a stable prompt prefix (e.g. the formatted system block) whose KV cells are
+    /// then kept across turns via `resetContext(keepingTokens:)`. Returns the total
+    /// token count now in the context (pass it back as `keepingTokens`), or -1 on
+    /// failure.
+    public func ingest(_ text: String) -> Int32 {
+        guard prepareContext(for: text) else { return -1 }
+        shouldContinuePredicting = false
+        return currentTokenCount
     }
     
     func generateResponseStream(from input: String, thinking: ThinkingMode = .none) -> AsyncStream<String> {
@@ -1485,6 +1511,23 @@ open class LLM: ObservableObject {
             await core.setStopSequence(nil)
             await core.setThinkingTokens(start: nil, end: nil, startMarker: nil, endMarker: nil)
         }
+    }
+    
+    /// Decode a stable prompt prefix (e.g. the fully formatted system block) into
+    /// the context without generating. Returns the prefix token count to pass to
+    /// `resetContext(keepingPrefixTokens:)` on later turns, or -1 on failure. Call
+    /// on a freshly reset context.
+    public func primeContext(_ text: String) async -> Int32 {
+        await core.ingest(text)
+    }
+    
+    /// Reset for a new turn while keeping a previously primed prefix's KV cells.
+    /// Re-decoding a large system prompt every turn dominates time-to-first-token;
+    /// priming it once and keeping it makes later turns pay only for the
+    /// conversation suffix.
+    public func resetContext(keepingPrefixTokens n: Int32) async {
+        history.removeAll()
+        await core.resetContext(keepingTokens: n)
     }
     
     open func recoverFromLengthy(_ input: borrowing String, to output: borrowing AsyncStream<String>.Continuation) {


### PR DESCRIPTION
We ship LLM.swift in a production iOS travel app (multi-turn on-device chat with Qwen 3). Two race conditions bit us in the field, and one performance pattern was worth upstreaming. All changes are additive — no existing API changes behavior.

### 1. Awaitable `resetContext()` / `syncTemplate()` (commit 1)

`reset()` clears the KV cache inside a fire-and-forget `Task`, and the `template` didSet applies the stop sequence + thinking tokens the same way. A `respond()` issued right after either call can win the race to the core actor:

- respond before the KV clear → the prompt decodes onto stale cells → degenerate or empty output (we saw this in the field as "the bot answers once, then never again");
- respond before the stop sequence lands → generation runs straight through the end-of-turn marker and answers twice.

`resetContext()` and `syncTemplate()` are awaitable equivalents so callers can guarantee ordering:

```swift
await bot.resetContext()      // KV clear has landed when this returns
bot.template = .chatML(system)
await bot.syncTemplate()      // stop sequence + thinking tokens applied
await bot.respond(to: prompt)
```

`reset()` and the didSet behavior are untouched for compatibility.

### 2. KV prefix caching: `ingest()` + `resetContext(keepingTokens:)` (commit 2)

Callers that manage history themselves re-decode their full prompt every turn, and the stable system block dominates that cost — time-to-first-token pays for the whole system prompt on every single turn. These primitives let a caller decode the stable prefix once and keep its KV cells across turns:

```swift
let prefixTokens = await bot.primeContext("<|im_start|>system\n\(system)<|im_end|>\n")
// per turn:
await bot.resetContext(keepingPrefixTokens: prefixTokens)
await bot.respond(to: conversationSuffix)   // decodes only the suffix
```

Measured on M-series Metal with a ~2.7KB system prompt (time to first token, turns after the first): Qwen3-1.7B 1.1s → 0.2s, Qwen3-4B 3.0s → ~0.5s, Qwen3-8B 9.4s → 1–4s.

This commit also makes `prepareContext` encode BOS only at position 0 — continuing after kept tokens must not inject BOS mid-stream.

### Testing

Verified with a standalone multi-turn harness (real weights, streaming through `respond`/`update`): 4 back-to-back turns each on Qwen3-1.7B/4B/8B Q4_K_M produce correct, context-aware answers; prefix-cached turns match uncached output quality.

Happy to split this into two PRs if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
