### PR TITLE
Scope interruption per generation — stop() currently strands one generation and kills the next

### DIFF
--- a/Sources/LLM/LLM.swift
+++ b/Sources/LLM/LLM.swift
@@ -32,20 +32,65 @@ public typealias Chat = (role: Role, content: String)
 /// context management, and inference. It ensures thread safety by using Swift's
 /// actor isolation.
 public actor LLMCore {
-    // the generation loop is one non-suspending actor job, so cancellation
-    // must live outside actor isolation to be visible mid-loop
-    private nonisolated let interruption = OSAllocatedUnfairLock(initialState: false)
+    // The generation loop is one non-suspending actor job, so cancellation must
+    // live outside actor isolation to be visible mid-loop.
+    //
+    // Cancellation is tracked PER GENERATION rather than as one shared flag.
+    // A single flag has two opposite failure modes, because "clear it" and
+    // "set it" both race against a generation starting:
+    //   • cleared too early — a new generation clearing the flag wipes the
+    //     cancellation aimed at the previous one, which then runs to completion
+    //     and blocks the actor (the new request waits behind it);
+    //   • still set too late — a leftover flag makes the next generation exit
+    //     before it emits a single token.
+    // Epochs remove both: an interrupt names the generation it is aimed at, and
+    // a new generation gets an epoch nothing has interrupted yet, so no clearing
+    // step is needed at all.
+    private struct InterruptionState {
+        var epoch: UInt64 = 0
+        var interruptedEpoch: UInt64?
+    }
 
+    private nonisolated let interruption = OSAllocatedUnfairLock(initialState: InterruptionState())
+
+    /// Claim the next generation epoch. Called once per generation, before its
+    /// task starts, so the epoch can be captured by that generation's loop and
+    /// by its stream-termination handler.
+    nonisolated func beginGenerationEpoch() -> UInt64 {
+        interruption.withLock { state in
+            state.epoch &+= 1
+            return state.epoch
+        }
+    }
+
+    /// Interrupt one specific generation. A stale interrupt (aimed at a
+    /// generation that already ended) can never affect a later one.
+    nonisolated func interrupt(epoch: UInt64) {
+        interruption.withLock { $0.interruptedEpoch = epoch }
+    }
+
+    /// Interrupt whichever generation is current — what `LLM.stop()` means.
+    /// Safe to call with nothing running: it marks the current epoch, and the
+    /// next generation claims a new one.
     public nonisolated func interrupt() {
-        interruption.withLock { $0 = true }
+        interruption.withLock { $0.interruptedEpoch = $0.epoch }
     }
 
+    /// Drop a pending interrupt. No longer needed to start a generation
+    /// (epochs make that implicit) and deliberately NOT called on that path —
+    /// doing so is what stranded the previous generation. Kept for callers
+    /// that want to explicitly rescind a stop.
     public nonisolated func clearInterruption() {
-        interruption.withLock { $0 = false }
+        interruption.withLock { $0.interruptedEpoch = nil }
     }
 
+    nonisolated func isInterrupted(epoch: UInt64) -> Bool {
+        interruption.withLock { $0.interruptedEpoch == epoch }
+    }
+
+    /// Whether the current generation has been interrupted.
     nonisolated var isInterrupted: Bool {
-        interruption.withLock { $0 }
+        interruption.withLock { $0.interruptedEpoch == $0.epoch }
     }
 
     private let model: Model
@@ -368,9 +413,14 @@ public actor LLMCore {
         let thinkingStream = AsyncStream<String> { thinkingContinuation = $0 }
         let responseStream = AsyncStream<String> { responseContinuation = $0 }
 
+        // Claim this generation's epoch before the task starts, so both the
+        // termination handler and the loop below refer to THIS generation and
+        // not to whatever happens to be current when they run.
+        let epoch = beginGenerationEpoch()
+
         responseContinuation.onTermination = { [weak self] reason in
             if case .cancelled = reason {
-                self?.interrupt()
+                self?.interrupt(epoch: epoch)
             }
         }
 
@@ -439,7 +489,7 @@ public actor LLMCore {
                 pendingText.removeFirst(overflowLength)
             }
             
-            while !isInterrupted && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
+            while !isInterrupted(epoch: epoch) && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
                 let excludedTokens = shouldGuaranteeOutput ? [endToken] : []
                 let token = predictNextToken(excluding: excludedTokens)
                 shouldGuaranteeOutput = false
@@ -512,9 +562,13 @@ public actor LLMCore {
         let responseStream = AsyncStream<String> { responseContinuation = $0 }
         let completionStream = AsyncStream<GeneratedMessage> { completionContinuation = $0 }
 
+        // See generateResponseStreamWithThinking: the epoch is claimed up front
+        // so cancellation names this generation specifically.
+        let epoch = beginGenerationEpoch()
+
         responseContinuation.onTermination = { [weak self] reason in
             if case .cancelled = reason {
-                self?.interrupt()
+                self?.interrupt(epoch: epoch)
             }
         }
 
@@ -544,7 +598,7 @@ public actor LLMCore {
             }
 
             var isFirstToken = true
-            while !isInterrupted && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
+            while !isInterrupted(epoch: epoch) && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
                 let token = predictNextToken(excluding: isFirstToken ? [endToken] : [])
                 isFirstToken = false
                 if token == endToken || token == endOfTurnToken { break }
@@ -640,6 +694,7 @@ public actor LLMCore {
     
     public func generateWithConstraints(from input: String, jsonSchema: String, thinking: ThinkingMode = .suppressed) throws -> String {
         debugLastGeneratedTokens = []
+        let epoch = beginGenerationEpoch()
         guard prepareContext(for: input) else { throw LLMError.contextCreationFailed }
 
         guard let grammarPointer = llm_chat_grammar_from_json_schema(jsonSchema) else {
@@ -652,7 +707,7 @@ public actor LLMCore {
         defer { llama_sampler_free(constrainedSampler) }
 
         var output = ""
-        while !isInterrupted && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
+        while !isInterrupted(epoch: epoch) && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
             let token = llama_sampler_sample(constrainedSampler, context, batch.n_tokens - 1)
             if token == endToken || token == endOfTurnToken { break }
 
@@ -1193,8 +1248,10 @@ open class LLM: ObservableObject {
     }
     
     public func stop() {
+        // Synchronous and epoch-scoped: it stops the generation running now,
+        // and cannot leak into the next one. (A queued `stopGeneration()` could
+        // land mid-next-generation and kill it before its first token.)
         core.interrupt()
-        Task { await core.stopGeneration() }
     }
     
     public func reset() {
@@ -1211,7 +1268,6 @@ open class LLM: ObservableObject {
         
         isAvailable = false
         defer { isAvailable = true }
-        core.clearInterruption()
         
         let response = await core.generateResponseStream(from: input)
         var output = ""
@@ -1228,7 +1284,6 @@ open class LLM: ObservableObject {
         
         isAvailable = false
         defer { isAvailable = true }
-        core.clearInterruption()
         
         self.input = input
         let processedInput = preprocess(input, history, thinking)
@@ -1250,7 +1305,6 @@ open class LLM: ObservableObject {
 
         isAvailable = false
         defer { isAvailable = true }
-        core.clearInterruption()
 
         self.input = input
 
@@ -1387,7 +1441,6 @@ open class LLM: ObservableObject {
         as type: T.Type,
         thinking: ThinkingMode = .none
     ) async throws -> StructuredOutput<T> {
-        core.clearInterruption()
         let schemaPrompt = """
         \(prompt)
         

--- a/Sources/LLM/LLM.swift
+++ b/Sources/LLM/LLM.swift
@@ -32,65 +32,41 @@ public typealias Chat = (role: Role, content: String)
 /// context management, and inference. It ensures thread safety by using Swift's
 /// actor isolation.
 public actor LLMCore {
-    // The generation loop is one non-suspending actor job, so cancellation must
-    // live outside actor isolation to be visible mid-loop.
-    //
-    // Cancellation is tracked PER GENERATION rather than as one shared flag.
-    // A single flag has two opposite failure modes, because "clear it" and
-    // "set it" both race against a generation starting:
-    //   • cleared too early — a new generation clearing the flag wipes the
-    //     cancellation aimed at the previous one, which then runs to completion
-    //     and blocks the actor (the new request waits behind it);
-    //   • still set too late — a leftover flag makes the next generation exit
-    //     before it emits a single token.
-    // Epochs remove both: an interrupt names the generation it is aimed at, and
-    // a new generation gets an epoch nothing has interrupted yet, so no clearing
-    // step is needed at all.
-    private struct InterruptionState {
-        var epoch: UInt64 = 0
-        var interruptedEpoch: UInt64?
+    // the generation loop is one non-suspending actor job, so interruption
+    // lives outside actor isolation; it is scoped to a single generation
+    // because setting or clearing a shared flag races the next generation's start
+    private struct Interruption {
+        var currentGeneration: UInt64 = 0
+        var interruptedGeneration: UInt64? = nil
     }
 
-    private nonisolated let interruption = OSAllocatedUnfairLock(initialState: InterruptionState())
+    private nonisolated let interruption = OSAllocatedUnfairLock(initialState: Interruption())
 
-    /// Claim the next generation epoch. Called once per generation, before its
-    /// task starts, so the epoch can be captured by that generation's loop and
-    /// by its stream-termination handler.
-    nonisolated func beginGenerationEpoch() -> UInt64 {
+    nonisolated func beginGeneration() -> UInt64 {
         interruption.withLock { state in
-            state.epoch &+= 1
-            return state.epoch
+            state.currentGeneration &+= 1
+            return state.currentGeneration
         }
     }
 
-    /// Interrupt one specific generation. A stale interrupt (aimed at a
-    /// generation that already ended) can never affect a later one.
-    nonisolated func interrupt(epoch: UInt64) {
-        interruption.withLock { $0.interruptedEpoch = epoch }
+    nonisolated func interrupt(generation: UInt64) {
+        interruption.withLock { $0.interruptedGeneration = generation }
     }
 
-    /// Interrupt whichever generation is current — what `LLM.stop()` means.
-    /// Safe to call with nothing running: it marks the current epoch, and the
-    /// next generation claims a new one.
     public nonisolated func interrupt() {
-        interruption.withLock { $0.interruptedEpoch = $0.epoch }
+        interruption.withLock { $0.interruptedGeneration = $0.currentGeneration }
     }
 
-    /// Drop a pending interrupt. No longer needed to start a generation
-    /// (epochs make that implicit) and deliberately NOT called on that path —
-    /// doing so is what stranded the previous generation. Kept for callers
-    /// that want to explicitly rescind a stop.
     public nonisolated func clearInterruption() {
-        interruption.withLock { $0.interruptedEpoch = nil }
+        interruption.withLock { $0.interruptedGeneration = nil }
     }
 
-    nonisolated func isInterrupted(epoch: UInt64) -> Bool {
-        interruption.withLock { $0.interruptedEpoch == epoch }
+    nonisolated func isInterrupted(_ generation: UInt64) -> Bool {
+        interruption.withLock { $0.interruptedGeneration == generation }
     }
 
-    /// Whether the current generation has been interrupted.
     nonisolated var isInterrupted: Bool {
-        interruption.withLock { $0.interruptedEpoch == $0.epoch }
+        interruption.withLock { $0.interruptedGeneration == $0.currentGeneration }
     }
 
     private let model: Model
@@ -368,11 +344,6 @@ public actor LLMCore {
         return token
     }
     
-    func stopGeneration() {
-        shouldContinuePredicting = false
-        interrupt()
-    }
-    
     private func injectTokensIntoContext(_ tokens: [Token]) -> Bool {
         for token in tokens {
             if let sampler {
@@ -413,14 +384,11 @@ public actor LLMCore {
         let thinkingStream = AsyncStream<String> { thinkingContinuation = $0 }
         let responseStream = AsyncStream<String> { responseContinuation = $0 }
 
-        // Claim this generation's epoch before the task starts, so both the
-        // termination handler and the loop below refer to THIS generation and
-        // not to whatever happens to be current when they run.
-        let epoch = beginGenerationEpoch()
+        let generation = beginGeneration()
 
         responseContinuation.onTermination = { [weak self] reason in
             if case .cancelled = reason {
-                self?.interrupt(epoch: epoch)
+                self?.interrupt(generation: generation)
             }
         }
 
@@ -489,7 +457,7 @@ public actor LLMCore {
                 pendingText.removeFirst(overflowLength)
             }
             
-            while !isInterrupted(epoch: epoch) && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
+            while !isInterrupted(generation) && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
                 let excludedTokens = shouldGuaranteeOutput ? [endToken] : []
                 let token = predictNextToken(excluding: excludedTokens)
                 shouldGuaranteeOutput = false
@@ -562,13 +530,11 @@ public actor LLMCore {
         let responseStream = AsyncStream<String> { responseContinuation = $0 }
         let completionStream = AsyncStream<GeneratedMessage> { completionContinuation = $0 }
 
-        // See generateResponseStreamWithThinking: the epoch is claimed up front
-        // so cancellation names this generation specifically.
-        let epoch = beginGenerationEpoch()
+        let generation = beginGeneration()
 
         responseContinuation.onTermination = { [weak self] reason in
             if case .cancelled = reason {
-                self?.interrupt(epoch: epoch)
+                self?.interrupt(generation: generation)
             }
         }
 
@@ -598,7 +564,7 @@ public actor LLMCore {
             }
 
             var isFirstToken = true
-            while !isInterrupted(epoch: epoch) && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
+            while !isInterrupted(generation) && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
                 let token = predictNextToken(excluding: isFirstToken ? [endToken] : [])
                 isFirstToken = false
                 if token == endToken || token == endOfTurnToken { break }
@@ -694,7 +660,7 @@ public actor LLMCore {
     
     public func generateWithConstraints(from input: String, jsonSchema: String, thinking: ThinkingMode = .suppressed) throws -> String {
         debugLastGeneratedTokens = []
-        let epoch = beginGenerationEpoch()
+        let generation = beginGeneration()
         guard prepareContext(for: input) else { throw LLMError.contextCreationFailed }
 
         guard let grammarPointer = llm_chat_grammar_from_json_schema(jsonSchema) else {
@@ -707,7 +673,7 @@ public actor LLMCore {
         defer { llama_sampler_free(constrainedSampler) }
 
         var output = ""
-        while !isInterrupted(epoch: epoch) && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
+        while !isInterrupted(generation) && shouldContinuePredicting && currentTokenCount < Int32(maxTokenCount) {
             let token = llama_sampler_sample(constrainedSampler, context, batch.n_tokens - 1)
             if token == endToken || token == endOfTurnToken { break }
 
@@ -1248,9 +1214,6 @@ open class LLM: ObservableObject {
     }
     
     public func stop() {
-        // Synchronous and epoch-scoped: it stops the generation running now,
-        // and cannot leak into the next one. (A queued `stopGeneration()` could
-        // land mid-next-generation and kill it before its first token.)
         core.interrupt()
     }
     

--- a/Tests/LLMTests/LLMTests.swift
+++ b/Tests/LLMTests/LLMTests.swift
@@ -226,11 +226,8 @@ final class LLMTests {
 
     //MARK: Interruption tests
 
-    /// Read at most `limit` tokens, optionally stopping the model at the limit.
-    /// Reads are bounded and history is cleared by the callers below so these
-    /// tests measure interruption only — an unbounded read lets the model
-    /// ramble, and the accumulated history then overruns the context, which
-    /// fails `prepareContext` for reasons that have nothing to do with `stop()`.
+    // reads are bounded so unbounded rambling cannot overrun the context,
+    // which would fail generation for reasons unrelated to interruption
     private func read(_ bot: LLM, _ prompt: String, limit: Int, stopping: Bool) async -> Int {
         var count = 0
         await bot.respond(to: prompt) { stream in
@@ -248,9 +245,6 @@ final class LLMTests {
         return count
     }
 
-    /// A `stop()` aimed at one generation must not leak into the next one.
-    /// Regression: with a single shared interruption flag, calling stop()
-    /// mid-generation left the following generation producing zero tokens.
     @Test
     func testStopDoesNotLeakIntoTheNextGeneration() async throws {
         let bot = try await LLM(from: model)!
@@ -262,9 +256,6 @@ final class LLMTests {
         #expect(produced > 0)
     }
 
-    /// Repeated stop/generate cycles must keep working — an interruption must
-    /// never latch on permanently. Regression: every cycle after the first
-    /// produced zero tokens.
     @Test
     func testRepeatedStopAndGenerateCycles() async throws {
         let bot = try await LLM(from: model)!

--- a/Tests/LLMTests/LLMTests.swift
+++ b/Tests/LLMTests/LLMTests.swift
@@ -223,6 +223,62 @@ final class LLMTests {
         let bot = try await LLM(from: model)!
         #expect(bot.preprocess(userPrompt, [], .none) == template.preprocess(userPrompt, [], .none))
     }
+
+    //MARK: Interruption tests
+
+    /// Read at most `limit` tokens, optionally stopping the model at the limit.
+    /// Reads are bounded and history is cleared by the callers below so these
+    /// tests measure interruption only — an unbounded read lets the model
+    /// ramble, and the accumulated history then overruns the context, which
+    /// fails `prepareContext` for reasons that have nothing to do with `stop()`.
+    private func read(_ bot: LLM, _ prompt: String, limit: Int, stopping: Bool) async -> Int {
+        var count = 0
+        await bot.respond(to: prompt) { stream in
+            var output = ""
+            for await delta in stream {
+                output += delta
+                count += 1
+                if count >= limit {
+                    if stopping { bot.stop() }
+                    break
+                }
+            }
+            return output
+        }
+        return count
+    }
+
+    /// A `stop()` aimed at one generation must not leak into the next one.
+    /// Regression: with a single shared interruption flag, calling stop()
+    /// mid-generation left the following generation producing zero tokens.
+    @Test
+    func testStopDoesNotLeakIntoTheNextGeneration() async throws {
+        let bot = try await LLM(from: model)!
+
+        _ = await read(bot, "Write a long story about the sea.", limit: 3, stopping: true)
+        bot.history.removeAll()
+
+        let produced = await read(bot, "Say hi.", limit: 5, stopping: false)
+        #expect(produced > 0)
+    }
+
+    /// Repeated stop/generate cycles must keep working — an interruption must
+    /// never latch on permanently. Regression: every cycle after the first
+    /// produced zero tokens.
+    @Test
+    func testRepeatedStopAndGenerateCycles() async throws {
+        let bot = try await LLM(from: model)!
+
+        for _ in 0..<3 {
+            _ = await read(bot, "Write a long story about the sea.", limit: 3, stopping: true)
+            bot.history.removeAll()
+
+            let produced = await read(bot, "Say hi.", limit: 5, stopping: false)
+            #expect(produced > 0)
+
+            bot.history.removeAll()
+        }
+    }
     
     lazy var embeddedTemplateModel = HuggingFaceModel("unsloth/Qwen3-0.6B-GGUF", .Q4_K_M)
 


### PR DESCRIPTION
Follow-up to #82. My fix there used a single shared interruption flag, and 3.0.0's changes exposed two opposite races around it. Both are reproducible on 3.0.1 with a real model (gemma-2-2b, M-series).

Apologies — the shared flag was my design, and #82 merged and released ~9 seconds apart, so this never got exercised against 3.0.0's architecture.

## The two failures

**1. Cleared too early → the abandoned generation strands.** `respond()` / `getCompletion()` call `clearInterruption()` on entry, so *starting* a generation wipes the cancellation aimed at the *previous* one. That generation then runs to completion holding the actor. Instrumented ordering:

```
onTermination reason=cancelled
interrupt()                    <- aimed at generation 1
clearInterruption()            <- generation 2 starting wipes it
loop EXIT interrupted=false    <- generation 1 never saw it
```

**2. Still set too late → the next generation dies.** A leftover flag makes the following generation exit before its first token. It also latches: after one `stop()`, *every* subsequent generation on that instance yields zero tokens.

`stop()` compounds it by queueing `Task { await core.stopGeneration() }`, which lands whenever the actor next frees up — possibly inside the following generation, clearing `shouldContinuePredicting` and killing it.

## Fix

Track cancellation **per generation** rather than as one shared bool:

- each generation claims an epoch (`beginGenerationEpoch()`) before its task starts;
- `interrupt(epoch:)` names the generation it targets, and each loop checks its own epoch;
- `stop()` keeps the no-arg `interrupt()` (= "stop what's running now") and drops the queued `stopGeneration()`;
- the four `clearInterruption()` calls on the start path are **removed** — a new generation gets an epoch nothing has interrupted, so no clearing step is needed. `clearInterruption()` remains public for callers who want to rescind a stop.

This removes both races structurally: there is no longer a window in which clearing is required for correctness.

## Measurements

Abandon a generation after 5 tokens, then time the next request's first token. Same probe, same model, same machine — only the library differs:

| | teardown (break the `for await`) | explicit `stop()` |
|---|---|---|
| 3.0.1 | 32,000 ms — blocked | no tokens at all |
| this change | **75 ms** | **71 ms** |

## Tests

Two regression tests added. They fail on 3.0.1 (4 failed expectations) and pass on this change across repeated runs.

Reads are bounded and history cleared in them on purpose: with an unbounded read the model rambles, accumulated history overruns the context, and `prepareContext` fails for reasons unrelated to `stop()` — which made an earlier draft of these tests flaky. Bounded, they run in ~1.3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)